### PR TITLE
Use the bdist_wheel command directly to build dependencies

### DIFF
--- a/vdt/versionplugin/buildout/shared.py
+++ b/vdt/versionplugin/buildout/shared.py
@@ -106,6 +106,11 @@ def build_from_python_source_with_wheel(
     target_wheel_dir = os.path.join(os.getcwd(), 'dist')
     with change_directory(target_path):
         try:
+            # The 'pip wheel' command is using subprocess to call
+            # 'setup.py bdist_wheel'. This sucks as we loose the complete
+            # context (pip wheel uses sys.executable as python
+            # interpeter). So calling it ourselves like this makes sure
+            # we use the correct interpreter, using buildout or virtualenv
             cmd = ['python', 'setup.py', 'bdist_wheel']
             log.debug("Running command {0}".format(" ".join(cmd)))
             log.debug(subprocess.check_output(cmd, cwd=target_path))
@@ -117,8 +122,8 @@ def build_from_python_source_with_wheel(
             return 1
 
         # move wheels to correct directory
-        for file in glob.glob(os.path.join(target_path, 'dist', '*.whl')):
-            shutil.move(file, target_wheel_dir)
+        for wheel in glob.glob(os.path.join(target_path, 'dist', '*.whl')):
+            shutil.move(wheel, target_wheel_dir)
 
 
 def write_requirements_txt(


### PR DESCRIPTION
So building dependencies is done with the correct setuptools and pip/wheel packages. (No need for a system wide wheel package anymore).

This only works when you have a python interpreter defined in your buildout, for example:

```
[vdt]
recipe = zc.recipe.egg:scripts
interpreter = python
eggs =
    vdt.version
    vdt.versionplugin.buildout
    vdt.versionplugin.debianize
    vdt.versionplugin.wheel
    vdt.recipe.version
    setupreader
dependent-scripts = true
```
